### PR TITLE
generate-all option + some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Note this is currently only setup to check for USER installed flatpak's, not sys
 1. Ensure ~/.local/bin/ is in PATH. Most distros already have this setup, but if not, then: echo PATH="$HOME/.local/bin:$HOME/bin:$PATH" >> ~/.bash_profile
 2. Copy flatpak-symlinker to ~/.local/bin and ensure it's executable (chmod +x flatpak-symlinker && cp flatpak-symlinker ~/.local/bin/)
 3. If it does not already exist, create ~/.config/systemd/user, then copy the systemd service file over (mkdir -p ~/.config/systemd/user && cp flatpak-symlinker.service ~/.config/systemd/user/)
-4. Daemon-reload systemd and enable the service. (systemctl --user daemon-reload && systemctl --user flatpak-symlinker enable --now)
+4. Daemon-reload systemd and enable the service. (systemctl --user daemon-reload && systemctl --user enable --now flatpak-symlinker)
 
 ## How it works:
 
@@ -31,3 +31,14 @@ For this reason, make sure you already have inotify-tools installed on your mach
 When a flatpak app is installed, it creates a temporary file there called .exports.symlink.something, it then renames it to the flatpak name. This is the functionality that by default allows users to run a flatpak by its name rather than call 'flatpak run something.something.something'. Then, we check for the command that the flatpak runs inside it's container (you can view this from flatpak metadata), and create a new symlink in .local/bin/ following the command. This makes user based flatpak installs a bit more sane.
 
 Upon file deletion from this directory, it simply removes broken symlinks in the directory, nothing fancy.
+
+## Run options:
+
+Run with `-h` to show help info:
+
+```shell
+flatpak-symlinker [-d] [-h] [-g]
+-d: Disable overwrite functionality entirely
+-h: Display this help message
+-g: Generate symlinks for all installed flatpaks at once
+```

--- a/flatpak-symlinker
+++ b/flatpak-symlinker
@@ -5,22 +5,11 @@ overwrite_disabled=false
 
 # Function to display usage message
 usage() {
-    echo "Usage: $0 [-f] [-d] [-h]"
+    echo "Usage: $0 [-d] [-h] [-g]"
     echo "-d: Disable overwrite functionality entirely"
     echo "-h: Display this help message"
+    echo "-g: Generate symlinks for all installed flatpaks at once"
 }
-
-# Parse command-line options
-while getopts 'fdh' opt; do
-    case "$opt" in
-        d) overwrite_disabled=true ;;
-        h) usage; exit 0 ;;
-        *) usage; exit 1 ;;
-    esac
-done
-
-# Shift positional parameters
-shift $((OPTIND-1))
 
 # Set paths for Flatpak exports and shortname bin
 flatpak_bin_exports="$HOME/.local/share/flatpak/exports/bin"
@@ -84,9 +73,42 @@ handle_symlink() {
     fi
 }
 
-# Monitor the directory for updates using inotifywait
-inotifywait -q -m -e MOVED_TO -e delete $flatpak_bin_exports |
-while read path event flatpak_name; do
-    flatpak_app_path=$path$flatpak_name
-    handle_symlink "$event" "$flatpak_name" "$flatpak_app_path"
+inotify_wait_forever() {
+    # Monitor the directory for updates using inotifywait
+    inotifywait -q -m -e MOVED_TO -e delete $flatpak_bin_exports |
+    while read path event flatpak_name; do
+        flatpak_app_path=$path$flatpak_name
+        handle_symlink "$event" "$flatpak_name" "$flatpak_app_path"
+    done
+}
+
+generate_all() {
+    flatpaks=( $(ls "$flatpak_bin_exports") )
+    [ -z "$flatpaks" ] && log_info "No installed flatpaks found" && exit 0
+
+    echo "Found installed flatpaks:"
+    for app in ${flatpaks[@]}; do echo " > $app"; done
+    read -p "Do you want me to create symlinks for these flatpaks? [Y]" -n 1 -r
+    echo    # (optional) move to a new line
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        for app in ${flatpaks[@]}; do 
+            handle_symlink "MOVED_TO" "$app" "$flatpak_bin_exports/$app"
+        done
+    fi
+}
+
+# Parse command-line options
+while getopts 'dhg' opt; do
+    case "$opt" in
+        d) overwrite_disabled=true ;;
+        h) usage; exit 0 ;;
+        g) generate_all; exit $? ;;
+        *) usage; exit 1 ;;
+    esac
 done
+
+# Shift positional parameters
+shift $((OPTIND-1))
+
+inotify_wait_forever

--- a/flatpak-symlinker.service
+++ b/flatpak-symlinker.service
@@ -3,7 +3,7 @@ Description=Symlinks flatpak's to their normal binary name, so you can call apps
 
 [Service]
 Type=simple
-ExecStart=/home/techtino/.local/bin/flatpak-symlinker
+ExecStart=%h/.local/bin/flatpak-symlinker
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This seems just the tool I'm missing to use flatpak, thanks!.

2 issues (fixed):

- service file contained maintainers own home folder
- systemctl command issue (fixed / tested for pop/ubuntu, assuming it's the same on other distro's/systemd versions)

Additional `-g` flag to generate symlinks for all installed flatpaks.
Helped me to get started.